### PR TITLE
Fix: Address issues with OK button, init_libs.sh script, and upload speed for ESP32-S3

### DIFF
--- a/init_libs.sh
+++ b/init_libs.sh
@@ -2,7 +2,12 @@
 
 echo "Downloading duktape..."
 wget https://duktape.org/duktape-2.7.0.tar.xz -O duktape-2.7.0.tar.xz
+
+echo "Preparing extraction folder..."
+mkdir -p lib/duktape-2.7.0
+
 echo "Extracting duktape..."
-tar -xvf duktape-2.7.0.tar.xz -C lib/duktape-2.7.0
+tar -xvf duktape-2.7.0.tar.xz -C lib/duktape-2.7.0 --strip-components=1
+
 echo "Cleanup..."
 rm -rf duktape-2.7.0.tar.xz

--- a/lib/Peripherals/boards/esp32_s3_devkitc/Peripherals_ESP32S3_DevKitC.hpp
+++ b/lib/Peripherals/boards/esp32_s3_devkitc/Peripherals_ESP32S3_DevKitC.hpp
@@ -44,6 +44,7 @@ public:
     down_btn.read();
     left_btn.read();
     right_btn.read();
+    ok_btn.read();
   }
 };
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -52,6 +52,7 @@ board = esp32-s3-devkitc-1
 board_build.partitions = 16mb.csv
 board_upload.flash_size = 16MB
 board_upload.maximum_size = 16777216
+upload_speed = 115200
 lib_deps = 
 	${common.lib_deps_builtin}
 	${common.lib_deps_external}


### PR DESCRIPTION
1. Fix: Add missing ok_btn.read() call to loop_code
Description:
This fix addresses an issue where the OK button on the ESP32-S3 DevKitC board was not functioning as expected. The problem was caused by a missing ok_btn.read() method call in the loop_code() method, which is required by the EasyButton library to properly detect button presses.

2. Fix: Correct extraction path in init_libs.sh script
Description:
This fix corrects the extraction path in the init_libs.sh script where the tar command failed due to an incorrect extraction path when attempting to extract the duktape-2.7.0.tar.xz file. The script now creates the correct directory before extracting, ensuring the extraction works without issues.

3. Fix: Specify upload_speed in platformio.ini for ESP32-S3
Description:
This update specifies the upload_speed parameter in the platformio.ini file for the ESP32-S3 board. This ensures that the upload speed is set to an optimal value, preventing upload issues caused by an excessively high data transfer rate during the firmware upload process.