### PR TITLE
Fix: Define TFT_BLK pin for LCD backlight control for ESP32-S3

### DIFF
--- a/include/boards/esp32_s3_devkitc/pins.h
+++ b/include/boards/esp32_s3_devkitc/pins.h
@@ -33,6 +33,7 @@
 #define TFT_MOSI 11
 #define TFT_MISO -1
 #define TFT_SCLK 12
+#define TFT_BLK 48
 
 // SD card
 #define SD_CARD_CS 13


### PR DESCRIPTION
The TFT_BLK pin was undefined in the code, which prevented the LCD backlight from being properly controlled. This change defines GPIO 48 as the default pin for TFT_BLK.

Is this omission intentional for hardware flexibility?
